### PR TITLE
Feat: add tiktok pixel cookie id to land pageviews

### DIFF
--- a/db/migrate/20231107214407_add_tiktok_pixel_cookie_id_to_page_view.rb
+++ b/db/migrate/20231107214407_add_tiktok_pixel_cookie_id_to_page_view.rb
@@ -1,0 +1,5 @@
+class AddTiktokPixelCookieIdToPageView < ActiveRecord::Migration[7.0]
+  def change
+    add_column "#{Land.config.schema}.pageviews", :tiktok_pixel_cookie_id, :text
+  end
+end

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -20,35 +20,36 @@ module Land
     #
     # https://strackr.com/subid
     TRACKING_PARAMS = {
-      'ad_group'       => %w[ad_group adgroup adset_name ovadgrpid ysmadgrpid],
-      'ad_type'        => %w[ad_type adtype],
-      'affiliate'      => %w[affiliate aff affid],
-      'app'            => %w[aid],
-      'bid_match_type' => %w[bidmatchtype bid_match_type bmt],
-      'brand'          => %w[brand brand_name],
-      'campaign'       => %w[campaign campaign_name utm_campaign ovcampgid ysmcampgid cn],
-      'campaign_identifier' => %w[campaign_identifier campaignidentifier campaignid campaign_id cid utm_campaign_id],
-      'click_id'       => %w[click_id clickid dclid fbclid gclid gclsrc msclkid zanpid ttclid ttp],
-      'content'        => %w[content ad_name utm_content cc],
-      'content_identifier' => %w[content_identifier contentidentifier contentid content_id cntid utm_content_id],
-      'creative'       => %w[creative adid ovadid],
-      'device_type'    => %w[device_type devicetype device],
-      'experiment'     => %w[experiment aceid],
-      'keyword'        => %w[keyword kw utm_term ovkey ysmkey],
-      'match_type'     => %w[match_type matchtype match ovmtc ysmmtc],
-      'medium'         => %w[medium utm_medium cm],
-      'medium_identifier' => %w[medium_identifier mediumidentifier mediumid medium_id mid utm_medium_id],
-      'network'        => %w[network anid],
-      'placement'      => %w[placement],
-      'position'       => %w[position adposition ad_position],
-      'search_term'    => %w[search_term searchterm q querystring ovraw ysmraw],
-      'source'         => %w[source utm_source cs],
-      'subsource'      => %w[subsource subid sid effi_id customid afftrack pubref argsite fobs epi ws u1],
-      'target'         => %w[target]
+      'ad_group'               => %w[ad_group adgroup adset_name ovadgrpid ysmadgrpid],
+      'ad_type'                => %w[ad_type adtype],
+      'affiliate'              => %w[affiliate aff affid],
+      'app'                    => %w[aid],
+      'bid_match_type'         => %w[bidmatchtype bid_match_type bmt],
+      'brand'                  => %w[brand brand_name],
+      'campaign'               => %w[campaign campaign_name utm_campaign ovcampgid ysmcampgid cn],
+      'campaign_identifier'    => %w[campaign_identifier campaignidentifier campaignid campaign_id cid utm_campaign_id],
+      'click_id'               => %w[click_id clickid dclid fbclid gclid gclsrc msclkid zanpid ttclid],
+      'content'                => %w[content ad_name utm_content cc],
+      'content_identifier'     => %w[content_identifier contentidentifier contentid content_id cntid utm_content_id],
+      'creative'               => %w[creative adid ovadid],
+      'device_type'            => %w[device_type devicetype device],
+      'experiment'             => %w[experiment aceid],
+      'keyword'                => %w[keyword kw utm_term ovkey ysmkey],
+      'match_type'             => %w[match_type matchtype match ovmtc ysmmtc],
+      'medium'                 => %w[medium utm_medium cm],
+      'medium_identifier'      => %w[medium_identifier mediumidentifier mediumid medium_id mid utm_medium_id],
+      'network'                => %w[network anid],
+      'placement'              => %w[placement],
+      'position'               => %w[position adposition ad_position],
+      'search_term'            => %w[search_term searchterm q querystring ovraw ysmraw],
+      'source'                 => %w[source utm_source cs],
+      'subsource'              => %w[subsource subid sid effi_id customid afftrack pubref argsite fobs epi ws u1],
+      'target'                 => %w[target],
+      'tiktok_pixel_cookie_id' => %w[ttp]
     }.freeze
 
     TRACKING_KEYS    = TRACKING_PARAMS.values.flatten.freeze
-    ATTRIBUTION_KEYS = TRACKING_PARAMS.except('click_id').keys
+    ATTRIBUTION_KEYS = TRACKING_PARAMS.except('click_id', 'tiktok_pixel_cookie_id').keys
 
     TRACKING_PARAMS_TRANSFORM = {
       'ad_type'        => { 'pe'  => 'product_extensions',

--- a/lib/land/trackers/user_tracker.rb
+++ b/lib/land/trackers/user_tracker.rb
@@ -28,24 +28,25 @@ module Land
         current_time = Time.now
 
         @pageview = Pageview.create do |p|
-          p.path          = request.path.to_s
+          p.path                         = request.path.to_s
 
-          p.http_method   = request.method
-          p.mime_type     = request.media_type || request.format.to_s
-          p.query_string  = untracked_params.to_query
-          p.request_id    = request.uuid
+          p.http_method                 = request.method
+          p.mime_type                   = request.media_type || request.format.to_s
+          p.query_string                = untracked_params.to_query
+          p.request_id                  = request.uuid
 
-          p.click_id      = tracking_params['click_id']
+          p.click_id                    = tracking_params['click_id']
+          p.tiktok_pixel_cookie_id      = tracking_params['tiktok_pixel_cookie_id']
 
-          p.http_status   = status || response.status
+          p.http_status                 = status || response.status
 
-          p.visit_id      = @visit_id
+          p.visit_id                    = @visit_id
 
-          p.created_at    = current_time
-          p.response_time = (current_time - @start_time) * 1000
+          p.created_at                  = current_time
+          p.response_time               = (current_time - @start_time) * 1000
         end
       end
-      
+
       def save
         record_pageview
 


### PR DESCRIPTION
This PR:
- adds the TikTok Pixel Click ID field to the Land::Pageviews table
- adds logic to Tracker/UserTracker to parse the field from the query param `tpp`