### PR TITLE
Feat/eliminate pg error move from find or created to find then create

### DIFF
--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end


### PR DESCRIPTION
 Eliminate pg error by moving `Cookie` and `Visit` creation from `find_or_create_by` to `where` and predicating the `create` on the result of the lookup.