### PR TITLE
update referer for a visit if seen on api calls

### DIFF
--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -14,6 +14,7 @@ module Land
         # visit API call. If the visit is created on a different call, the query
         # string will be updated whenever the visit API call is completed.
         maybe_update_visit_attribution
+        maybe_update_visit_referer
       end
 
       # Overriding record_visit method as we set the visit id from the API param,
@@ -122,6 +123,13 @@ module Land
         visit = Visit.find(@visit_id)
         visit.update(raw_query_string: request.query_string) unless visit.raw_query_string.present?
         visit.update(attribution:) unless attribution_values_present?(visit)
+      end
+
+      def maybe_update_visit_attribution
+        return unless referer_uri.present?
+
+        visit = Visit.find(@visit_id)
+        visit.update(referer: referer) unless visit.referer.present?
       end
 
       def attribution_values_present?(visit)

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -125,7 +125,7 @@ module Land
         visit.update(attribution:) unless attribution_values_present?(visit)
       end
 
-      def maybe_update_visit_attribution
+      def maybe_update_visit_referer
         return unless referer_uri.present?
 
         visit = Visit.find(@visit_id)


### PR DESCRIPTION
Update visit.referer once available so it can be used for lead submission as the domain submitting the lead.