### PR TITLE
[ENG-771] feat/add-unaltered_ingress_url-to-land-visits

### DIFF
--- a/db/migrate/20241209201633_add_unaltered_ingress_url_to_visits.rb
+++ b/db/migrate/20241209201633_add_unaltered_ingress_url_to_visits.rb
@@ -1,0 +1,5 @@
+class AddUnalteredIngressUrlToVisits < ActiveRecord::Migration[7.0]
+  def change
+    add_column 'land.visits', :unaltered_ingress_url, :text
+  end
+end

--- a/db/migrate/20241218175001_add_land_visits_click_id.rb
+++ b/db/migrate/20241218175001_add_land_visits_click_id.rb
@@ -1,0 +1,5 @@
+class AddLandVisitsClickId < ActiveRecord::Migration[7.0]
+  def change
+    add_column 'land.visits', :click_id, :text
+  end
+end

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -17,8 +17,9 @@ module Land
         maybe_set_unaltered_ingress_url
         maybe_set_visit_attribution
         maybe_set_visit_referer
+        maybe_set_click_id
 
-        @visit.save if @visit.changed?
+        @visit.save! if @visit.changed?
       rescue StandardError => e
         Land.config.logger.error "Error recording visit: #{e.message}"
       end
@@ -118,6 +119,12 @@ module Land
         return unless request.params['referer'].present?
 
         @referer_uri ||= Addressable::URI.parse(request.params['referer'].sub(/\Awww\./i, '//\0'))
+      end
+
+      def maybe_set_click_id
+        return unless tracking_params['click_id'].present? && @visit.click_id.blank?
+
+        @visit.click_id = tracking_params['click_id']
       end
 
       def maybe_set_visit_attribution

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -15,6 +15,7 @@ module Land
         # string will be updated whenever the visit API call is completed.
         maybe_update_visit_attribution
         maybe_update_visit_referer
+        maybe_set_unaltered_ingress_url
       end
 
       # Overriding record_visit method as we set the visit id from the API param,
@@ -120,16 +121,21 @@ module Land
       def maybe_update_visit_attribution
         return unless attribution?
 
-        visit = Visit.find(@visit_id)
-        visit.update(raw_query_string: request.query_string) unless visit.raw_query_string.present?
-        visit.update(attribution:) unless attribution_values_present?(visit)
+        @visit.update(raw_query_string: request.query_string) unless visit.raw_query_string.present?
+        @visit.update(attribution:) unless attribution_values_present?(visit)
       end
 
       def maybe_update_visit_referer
         return unless referer_uri.present?
 
-        visit = Visit.find(@visit_id)
-        visit.update(referer: referer) unless visit.referer.present?
+        @visit = Visit.find(@visit_id)
+        @visit.update(referer:) unless visit.referer.present?
+      end
+
+      def maybe_set_unaltered_ingress_url
+        return unless @visit.unaltered_ingress_url.blank? && request.params['unaltered_ingress_url'].present?
+
+        @visit.update(unaltered_ingress_url: request.params['unaltered_ingress_url'])
       end
 
       def attribution_values_present?(visit)

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -143,7 +143,7 @@ module Land
       def maybe_set_visit_referer
         return unless referer_uri.present? || @visit.referer.present?
 
-        @visit.referer = referer
+        @visit.referer_id = referer.id
       end
 
       def maybe_set_unaltered_ingress_url

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -32,13 +32,14 @@ module Land
 
         @visit = Visit.create do |visit|
           visit.id = @visit_id
-          visit.attribution   = attribution
-          visit.cookie_id     = @cookie_id
-          visit.referer_id    = referer&.id
-          visit.user_agent_id = user_agent.id
-          visit.ip_address    = remote_ip
-          visit.domain_id     = request_domain&.id
+          visit.attribution      = attribution
+          visit.cookie_id        = @cookie_id
+          visit.referer_id       = referer&.id
+          visit.user_agent_id    = user_agent.id
+          visit.ip_address       = remote_ip
+          visit.domain_id        = request_domain&.id
           visit.raw_query_string = unescaped_query_string
+          visit.click_id         = tracking_params['click_id']
         end
 
         @visit_id

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -13,29 +13,31 @@ module Land
         # that is not the visit call. Query strings are passed from the front end
         # visit API call. If the visit is created on a different call, the query
         # string will be updated whenever the visit API call is completed.
-        maybe_update_visit_attribution
-        maybe_update_visit_referer
+        maybe_set_raw_query_string
         maybe_set_unaltered_ingress_url
+        maybe_set_visit_attribution
+        maybe_set_visit_referer
+
+        @visit.save if @visit.changed?
+      rescue StandardError => e
+        Land.config.logger.error "Error recording visit: #{e.message}"
       end
 
       # Overriding record_visit method as we set the visit id from the API param,
       # so we have to check the Land::Visit does not exist
       #
       def record_visit
-        case Visit.where(visit_id: @visit_id).first
-        in nil
-          @visit = Visit.create do |visit|
-            visit.id = @visit_id
-            visit.attribution   = attribution
-            visit.cookie_id     = @cookie_id
-            visit.referer_id    = referer&.id
-            visit.user_agent_id = user_agent.id
-            visit.ip_address    = remote_ip
-            visit.domain_id     = request_domain&.id
-            visit.raw_query_string = request.query_string
-          end
-        in visit
-          @visit = visit
+        return @visit_id if visit
+
+        @visit = Visit.create do |visit|
+          visit.id = @visit_id
+          visit.attribution   = attribution
+          visit.cookie_id     = @cookie_id
+          visit.referer_id    = referer&.id
+          visit.user_agent_id = user_agent.id
+          visit.ip_address    = remote_ip
+          visit.domain_id     = request_domain&.id
+          visit.raw_query_string = unescaped_query_string
         end
 
         @visit_id
@@ -118,24 +120,28 @@ module Land
         @referer_uri ||= Addressable::URI.parse(request.params['referer'].sub(/\Awww\./i, '//\0'))
       end
 
-      def maybe_update_visit_attribution
-        return unless attribution?
+      def maybe_set_visit_attribution
+        return unless attribution? || attribution_values_present?(visit)
 
-        @visit.update(raw_query_string: request.query_string) unless visit.raw_query_string.present?
-        @visit.update(attribution:) unless attribution_values_present?(visit)
+        @visit.attribution = attribution
       end
 
-      def maybe_update_visit_referer
-        return unless referer_uri.present?
+      def maybe_set_raw_query_string
+        return unless request.query_string.present?
 
-        @visit = Visit.find(@visit_id)
-        @visit.update(referer:) unless visit.referer.present?
+        @visit.raw_query_string = unescaped_query_string
+      end
+
+      def maybe_set_visit_referer
+        return unless referer_uri.present? || @visit.referer.present?
+
+        @visit.referer = referer
       end
 
       def maybe_set_unaltered_ingress_url
         return unless @visit.unaltered_ingress_url.blank? && request.params['unaltered_ingress_url'].present?
 
-        @visit.update(unaltered_ingress_url: request.params['unaltered_ingress_url'])
+        @visit.unaltered_ingress_url = request.params['unaltered_ingress_url']
       end
 
       def attribution_values_present?(visit)
@@ -146,8 +152,16 @@ module Land
              .any?
       end
 
+      def unescaped_query_string
+        CGI.unescape(request.query_string)
+      end
+
+      def visit
+        @visit ||= Land::Visit.where(visit_id: @visit_id).first
+      end
+
       def new_visit?
-        Land::Visit.find_by(@visit_id).nil?
+        @visit.nil?
       end
     end
   end

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.13'
+  VERSION = '0.1.14'
 end


### PR DESCRIPTION
This PR:
- adds `land.visits.click_id` and sets it
- adds access and storing of `unalteredIngressUrl` on `land.visits`
- removes redundant lookups as the `@visit` is already in scope
