### PR TITLE
Fix/visit creation race condition

### DIFF
--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'digest/sha2'
-require 'uri'
-require 'addressable/uri'
+require "digest/sha2"
+require "uri"
+require "addressable/uri"
 
 module Land
   class Tracker
@@ -20,31 +20,31 @@ module Land
     #
     # https://strackr.com/subid
     TRACKING_PARAMS = {
-      'ad_group' => %w[ad_group adgroup adset_name ovadgrpid ysmadgrpid],
-      'ad_type' => %w[ad_type adtype],
-      'affiliate' => %w[affiliate aff affid],
-      'app' => %w[aid],
-      'bid_match_type' => %w[bidmatchtype bid_match_type bmt],
-      'brand' => %w[brand brand_name],
-      'campaign' => %w[campaign campaign_name utm_campaign ovcampgid ysmcampgid cn],
-      'campaign_identifier' => %w[campaign_identifier campaignidentifier campaignid campaign_id cid utm_campaign_id],
-      'click_id' => %w[click_id clickid dclid fbclid gclid gclsrc msclkid zanpid ttclid],
-      'content' => %w[content ad_name utm_content cc],
-      'content_identifier' => %w[content_identifier contentidentifier contentid content_id cntid utm_content_id],
-      'creative' => %w[creative adid ovadid],
-      'device_type' => %w[device_type devicetype device],
-      'experiment' => %w[experiment aceid],
-      'keyword' => %w[keyword kw utm_term ovkey ysmkey],
-      'match_type' => %w[match_type matchtype match ovmtc ysmmtc],
-      'medium' => %w[medium utm_medium cm],
-      'medium_identifier' => %w[medium_identifier mediumidentifier mediumid medium_id mid utm_medium_id],
-      'network' => %w[network anid],
-      'placement' => %w[placement],
-      'position' => %w[position adposition ad_position],
-      'search_term' => %w[search_term searchterm q querystring ovraw ysmraw],
-      'source' => %w[source utm_source cs],
-      'subsource' => %w[subsource subid sid effi_id customid afftrack pubref argsite fobs epi ws u1],
-      'target' => %w[target],
+      'ad_group'               => %w[ad_group adgroup adset_name ovadgrpid ysmadgrpid],
+      'ad_type'                => %w[ad_type adtype],
+      'affiliate'              => %w[affiliate aff affid],
+      'app'                    => %w[aid],
+      'bid_match_type'         => %w[bidmatchtype bid_match_type bmt],
+      'brand'                  => %w[brand brand_name],
+      'campaign'               => %w[campaign campaign_name utm_campaign ovcampgid ysmcampgid cn],
+      'campaign_identifier'    => %w[campaign_identifier campaignidentifier campaignid campaign_id cid utm_campaign_id],
+      'click_id'               => %w[click_id clickid dclid fbclid gclid gclsrc msclkid zanpid ttclid],
+      'content'                => %w[content ad_name utm_content cc],
+      'content_identifier'     => %w[content_identifier contentidentifier contentid content_id cntid utm_content_id],
+      'creative'               => %w[creative adid ovadid],
+      'device_type'            => %w[device_type devicetype device],
+      'experiment'             => %w[experiment aceid],
+      'keyword'                => %w[keyword kw utm_term ovkey ysmkey],
+      'match_type'             => %w[match_type matchtype match ovmtc ysmmtc],
+      'medium'                 => %w[medium utm_medium cm],
+      'medium_identifier'      => %w[medium_identifier mediumidentifier mediumid medium_id mid utm_medium_id],
+      'network'                => %w[network anid],
+      'placement'              => %w[placement],
+      'position'               => %w[position adposition ad_position],
+      'search_term'            => %w[search_term searchterm q querystring ovraw ysmraw],
+      'source'                 => %w[source utm_source cs],
+      'subsource'              => %w[subsource subid sid effi_id customid afftrack pubref argsite fobs epi ws u1],
+      'target'                 => %w[target],
       'tiktok_pixel_cookie_id' => %w[ttp]
     }.freeze
 
@@ -52,34 +52,34 @@ module Land
     ATTRIBUTION_KEYS = TRACKING_PARAMS.except('click_id', 'tiktok_pixel_cookie_id').keys
 
     TRACKING_PARAMS_TRANSFORM = {
-      'ad_type' => { 'pe' => 'product_extensions',
-                     'pla' => 'product_listing' },
+      'ad_type'        => { 'pe'  => 'product_extensions',
+                            'pla' => 'product_listing' },
 
-      'bid_match_type' => { 'bb' => 'bidded broad',
-                            'bc' => 'bidded content',
-                            'be' => 'bidded exact',
-                            'bp' => 'bidded phrase' },
+      'bid_match_type' => { 'bb'  => 'bidded broad',
+                            'bc'  => 'bidded content',
+                            'be'  => 'bidded exact',
+                            'bp'  => 'bidded phrase' },
 
-      'device_type' => { 'c' => 'computer',
-                         'm' => 'mobile',
-                         't' => 'tablet' },
+      'device_type'    => { 'c'   => 'computer',
+                            'm'   => 'mobile',
+                            't'   => 'tablet' },
 
-      'match_type' => { 'b' => 'broad',
-                        'c' => 'content',
-                        'e' => 'exact',
-                        'p' => 'phrase',
-                        'std' => 'standard',
-                        'adv' => 'advanced',
-                        'cnt' => 'content' },
+      'match_type'     => { 'b'   => 'broad',
+                            'c'   => 'content',
+                            'e'   => 'exact',
+                            'p'   => 'phrase',
+                            'std' => 'standard',
+                            'adv' => 'advanced',
+                            'cnt' => 'content' },
 
-      'network' => { 'g' => 'google_search',
-                     's' => 'search_partner',
-                     'd' => 'display_network' },
+      'network'        => { 'g'   => 'google_search',
+                            's'   => 'search_partner',
+                            'd'   => 'display_network' },
 
-      'source' => { 'fb' => 'facebook',
-                    'ig' => 'instagram',
-                    'msg' => 'messenger',
-                    'an' => 'audience network' }
+      'source'         => { 'fb'  => 'facebook',
+                            'ig'  => 'instagram',
+                            'msg' => 'messenger',
+                            'an'  => 'audience network' }
     }.freeze
 
     TRACKED_PARAMS = TRACKING_PARAMS.values.flatten.freeze
@@ -89,11 +89,11 @@ module Land
 
     # Compact the session by shortening names
     KEYS = {
-      visit_id: 'vid',
-      visit_time: 'vt',
-      user_agent_hash: 'uh',
+      visit_id:         'vid',
+      visit_time:       'vt',
+      user_agent_hash:  'uh',
       attribution_hash: 'ah',
-      referer_hash: 'rh'
+      referer_hash:     'rh'
     }.freeze
 
     attr_accessor :status
@@ -138,7 +138,7 @@ module Land
     end
 
     def track
-      raise NotImplementedError, 'You must subclass Land::Tracker' if self.class == Tracker
+      fail NotImplementedError, "You must subclass Land::Tracker" if self.class == Tracker
     end
 
     protected
@@ -179,10 +179,10 @@ module Land
       query       = params.except(*ATTRIBUTION_KEYS)
 
       begin
-        @referer = Referer.where(domain_id: Domain[referer_uri.host.to_s],
-                                 path_id: Path[referer_path],
+        @referer = Referer.where(domain_id:       Domain[referer_uri.host.to_s],
+                                 path_id:         Path[referer_path],
                                  query_string_id: QueryString[query.to_query],
-                                 attribution_id: attribution.id).first_or_create
+                                 attribution_id:  attribution.id).first_or_create
       rescue ActiveRecord::RecordNotUnique
         retry
       end
@@ -260,7 +260,7 @@ module Land
     end
 
     def new_visit?
-      @visit_id.nil? || Land.config.new_visit_reasons.map { |reason| send(reason.to_sym) }.any?
+      @visit_id.nil? || Land.config.new_visit_reasons.map{ |reason| send(reason.to_sym) }.any?
     end
 
     def external_referer?
@@ -273,13 +273,11 @@ module Land
       TRACKING_PARAMS.each do |key, names|
         param = names.find { |name| params.key?(name) }
         next unless param
-
         hash[key] = params[param]
       end
 
       TRACKING_PARAMS_TRANSFORM.each do |key, transform|
         next unless hash.key? key
-
         hash[key] = transform[hash[key]] if transform.key? hash[key]
       end
 
@@ -308,7 +306,6 @@ module Land
 
     def visit_stale?
       return false unless @last_visit_time
-
       Time.current - @last_visit_time > Land.config.visit_timeout
     end
   end

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "digest/sha2"
-require "uri"
-require "addressable/uri"
+require 'digest/sha2'
+require 'uri'
+require 'addressable/uri'
 
 module Land
   class Tracker
@@ -20,31 +20,31 @@ module Land
     #
     # https://strackr.com/subid
     TRACKING_PARAMS = {
-      'ad_group'               => %w[ad_group adgroup adset_name ovadgrpid ysmadgrpid],
-      'ad_type'                => %w[ad_type adtype],
-      'affiliate'              => %w[affiliate aff affid],
-      'app'                    => %w[aid],
-      'bid_match_type'         => %w[bidmatchtype bid_match_type bmt],
-      'brand'                  => %w[brand brand_name],
-      'campaign'               => %w[campaign campaign_name utm_campaign ovcampgid ysmcampgid cn],
-      'campaign_identifier'    => %w[campaign_identifier campaignidentifier campaignid campaign_id cid utm_campaign_id],
-      'click_id'               => %w[click_id clickid dclid fbclid gclid gclsrc msclkid zanpid ttclid],
-      'content'                => %w[content ad_name utm_content cc],
-      'content_identifier'     => %w[content_identifier contentidentifier contentid content_id cntid utm_content_id],
-      'creative'               => %w[creative adid ovadid],
-      'device_type'            => %w[device_type devicetype device],
-      'experiment'             => %w[experiment aceid],
-      'keyword'                => %w[keyword kw utm_term ovkey ysmkey],
-      'match_type'             => %w[match_type matchtype match ovmtc ysmmtc],
-      'medium'                 => %w[medium utm_medium cm],
-      'medium_identifier'      => %w[medium_identifier mediumidentifier mediumid medium_id mid utm_medium_id],
-      'network'                => %w[network anid],
-      'placement'              => %w[placement],
-      'position'               => %w[position adposition ad_position],
-      'search_term'            => %w[search_term searchterm q querystring ovraw ysmraw],
-      'source'                 => %w[source utm_source cs],
-      'subsource'              => %w[subsource subid sid effi_id customid afftrack pubref argsite fobs epi ws u1],
-      'target'                 => %w[target],
+      'ad_group' => %w[ad_group adgroup adset_name ovadgrpid ysmadgrpid],
+      'ad_type' => %w[ad_type adtype],
+      'affiliate' => %w[affiliate aff affid],
+      'app' => %w[aid],
+      'bid_match_type' => %w[bidmatchtype bid_match_type bmt],
+      'brand' => %w[brand brand_name],
+      'campaign' => %w[campaign campaign_name utm_campaign ovcampgid ysmcampgid cn],
+      'campaign_identifier' => %w[campaign_identifier campaignidentifier campaignid campaign_id cid utm_campaign_id],
+      'click_id' => %w[click_id clickid dclid fbclid gclid gclsrc msclkid zanpid ttclid],
+      'content' => %w[content ad_name utm_content cc],
+      'content_identifier' => %w[content_identifier contentidentifier contentid content_id cntid utm_content_id],
+      'creative' => %w[creative adid ovadid],
+      'device_type' => %w[device_type devicetype device],
+      'experiment' => %w[experiment aceid],
+      'keyword' => %w[keyword kw utm_term ovkey ysmkey],
+      'match_type' => %w[match_type matchtype match ovmtc ysmmtc],
+      'medium' => %w[medium utm_medium cm],
+      'medium_identifier' => %w[medium_identifier mediumidentifier mediumid medium_id mid utm_medium_id],
+      'network' => %w[network anid],
+      'placement' => %w[placement],
+      'position' => %w[position adposition ad_position],
+      'search_term' => %w[search_term searchterm q querystring ovraw ysmraw],
+      'source' => %w[source utm_source cs],
+      'subsource' => %w[subsource subid sid effi_id customid afftrack pubref argsite fobs epi ws u1],
+      'target' => %w[target],
       'tiktok_pixel_cookie_id' => %w[ttp]
     }.freeze
 
@@ -52,34 +52,34 @@ module Land
     ATTRIBUTION_KEYS = TRACKING_PARAMS.except('click_id', 'tiktok_pixel_cookie_id').keys
 
     TRACKING_PARAMS_TRANSFORM = {
-      'ad_type'        => { 'pe'  => 'product_extensions',
-                            'pla' => 'product_listing' },
+      'ad_type' => { 'pe' => 'product_extensions',
+                     'pla' => 'product_listing' },
 
-      'bid_match_type' => { 'bb'  => 'bidded broad',
-                            'bc'  => 'bidded content',
-                            'be'  => 'bidded exact',
-                            'bp'  => 'bidded phrase' },
+      'bid_match_type' => { 'bb' => 'bidded broad',
+                            'bc' => 'bidded content',
+                            'be' => 'bidded exact',
+                            'bp' => 'bidded phrase' },
 
-      'device_type'    => { 'c'   => 'computer',
-                            'm'   => 'mobile',
-                            't'   => 'tablet' },
+      'device_type' => { 'c' => 'computer',
+                         'm' => 'mobile',
+                         't' => 'tablet' },
 
-      'match_type'     => { 'b'   => 'broad',
-                            'c'   => 'content',
-                            'e'   => 'exact',
-                            'p'   => 'phrase',
-                            'std' => 'standard',
-                            'adv' => 'advanced',
-                            'cnt' => 'content' },
+      'match_type' => { 'b' => 'broad',
+                        'c' => 'content',
+                        'e' => 'exact',
+                        'p' => 'phrase',
+                        'std' => 'standard',
+                        'adv' => 'advanced',
+                        'cnt' => 'content' },
 
-      'network'        => { 'g'   => 'google_search',
-                            's'   => 'search_partner',
-                            'd'   => 'display_network' },
+      'network' => { 'g' => 'google_search',
+                     's' => 'search_partner',
+                     'd' => 'display_network' },
 
-      'source'         => { 'fb'  => 'facebook',
-                            'ig'  => 'instagram',
-                            'msg' => 'messenger',
-                            'an'  => 'audience network' }
+      'source' => { 'fb' => 'facebook',
+                    'ig' => 'instagram',
+                    'msg' => 'messenger',
+                    'an' => 'audience network' }
     }.freeze
 
     TRACKED_PARAMS = TRACKING_PARAMS.values.flatten.freeze
@@ -89,11 +89,11 @@ module Land
 
     # Compact the session by shortening names
     KEYS = {
-      visit_id:         'vid',
-      visit_time:       'vt',
-      user_agent_hash:  'uh',
+      visit_id: 'vid',
+      visit_time: 'vt',
+      user_agent_hash: 'uh',
       attribution_hash: 'ah',
-      referer_hash:     'rh'
+      referer_hash: 'rh'
     }.freeze
 
     attr_accessor :status
@@ -138,7 +138,7 @@ module Land
     end
 
     def track
-      fail NotImplementedError, "You must subclass Land::Tracker" if self.class == Tracker
+      raise NotImplementedError, 'You must subclass Land::Tracker' if self.class == Tracker
     end
 
     protected
@@ -179,10 +179,10 @@ module Land
       query       = params.except(*ATTRIBUTION_KEYS)
 
       begin
-        @referer = Referer.where(domain_id:       Domain[referer_uri.host.to_s],
-                                 path_id:         Path[referer_path],
+        @referer = Referer.where(domain_id: Domain[referer_uri.host.to_s],
+                                 path_id: Path[referer_path],
                                  query_string_id: QueryString[query.to_query],
-                                 attribution_id:  attribution.id).first_or_create
+                                 attribution_id: attribution.id).first_or_create
       rescue ActiveRecord::RecordNotUnique
         retry
       end
@@ -260,7 +260,7 @@ module Land
     end
 
     def new_visit?
-      @visit_id.nil? || Land.config.new_visit_reasons.map{ |reason| send(reason.to_sym) }.any?
+      @visit_id.nil? || Land.config.new_visit_reasons.map { |reason| send(reason.to_sym) }.any?
     end
 
     def external_referer?
@@ -273,11 +273,13 @@ module Land
       TRACKING_PARAMS.each do |key, names|
         param = names.find { |name| params.key?(name) }
         next unless param
+
         hash[key] = params[param]
       end
 
       TRACKING_PARAMS_TRANSFORM.each do |key, transform|
         next unless hash.key? key
+
         hash[key] = transform[hash[key]] if transform.key? hash[key]
       end
 
@@ -306,6 +308,7 @@ module Land
 
     def visit_stale?
       return false unless @last_visit_time
+
       Time.current - @last_visit_time > Land.config.visit_timeout
     end
   end

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -5,6 +5,8 @@ module Land
     class ApiTracker < Tracker
       attr_reader :pageview
 
+      VISIT_ENDPOINT_REGEX = %r{^/api/v\d+/visit$}
+
       def track
         load
         record_visit
@@ -13,15 +15,29 @@ module Land
         # that is not the visit call. Query strings are passed from the front end
         # visit API call. If the visit is created on a different call, the query
         # string will be updated whenever the visit API call is completed.
-        maybe_set_raw_query_string
-        maybe_set_unaltered_ingress_url
-        maybe_set_visit_attribution
-        maybe_set_visit_referer
-        maybe_set_user_agent
-        maybe_set_click_id
 
-        @visit.save! if @visit.changed?
+        # Here we only invoke the visit attribution update if the request is a
+        # visit API call
+        if controller.request.path =~ VISIT_ENDPOINT_REGEX
+          @visit.reload
+
+          maybe_set_raw_query_string
+          maybe_set_unaltered_ingress_url
+          maybe_set_visit_attribution
+          maybe_set_visit_referer
+          maybe_set_user_agent
+          maybe_set_click_id
+
+          @visit.save! if @visit.changed?
+        end
       rescue StandardError => e
+        # Here we are going to tag the span with the error if Datadog span
+        # exists This is called safely to avoid errors in the case that Datadog
+        # is not present
+        if defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
+          Datadog::Tracing.active_span&.set_error(e)
+        end
+
         Land.config.logger.error "Error recording visit: #{e.message}"
       end
 
@@ -31,16 +47,22 @@ module Land
       def record_visit
         return @visit_id if visit
 
-        @visit = Visit.create do |visit|
-          visit.id               = @visit_id
-          visit.attribution      = attribution
-          visit.cookie_id        = @cookie_id
-          visit.referer_id       = referer&.id
-          visit.user_agent_id    = user_agent&.id
-          visit.ip_address       = remote_ip
-          visit.domain_id        = request_domain&.id
-          visit.raw_query_string = referer_uri&.query
-          visit.click_id         = tracking_params['click_id']
+        begin
+          @visit = Visit.create do |visit|
+            visit.id               = @visit_id
+            visit.attribution      = attribution
+            visit.cookie_id        = @cookie_id
+            visit.referer_id       = referer&.id
+            visit.user_agent_id    = user_agent&.id
+            visit.ip_address       = remote_ip
+            visit.domain_id        = request_domain&.id
+            visit.raw_query_string = referer_uri&.query
+            visit.click_id         = tracking_params['click_id']
+          end
+          # This handles a race condition between the visit and other API requests
+          # ex: page_views, events, feature_flags
+        rescue ActiveRecord::RecordNotUnique
+          @visit = Visit.where(id: @visit_id).first
         end
 
         @visit_id

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.15'
+  VERSION = '0.1.16'
 end

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -195,4 +195,19 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(pageview.tiktok_pixel_cookie_id).to eq(nil)
     end
   end
+
+  context 'unit tests' do
+    let(:cookie_id) { SecureRandom.uuid }
+    let(:visit_id) { SecureRandom.uuid }
+
+    describe 'VISIT_ENDPOINT_REGEX' do
+      it 'matches the correct endpoint' do
+        expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to be_a(Regexp)
+        expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to match('/api/v1/visit')
+        expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to match('/api/v1121/visit')
+        expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to_not match('/api/v1/visitX')
+        expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to_not match('/apii/v1/visit')
+      end
+    end
+  end
 end


### PR DESCRIPTION
- fixes visit creation race condition
- only updates visit attribution if the visit call is being made

Context:

FrontEnd sends API requests in bursts, as they are all async and not order dependent. There was a race condition in visit creation where both would attempt to create the visit at the same time.