### PR TITLE
[ENG-3017] Allow visit attribution to be set when creating a pageview

### DIFF
--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -51,7 +51,7 @@ module Land
         return @visit_id if visit
 
         begin
-          @visit = Visit.create do |visit|
+          @visit = Visit.create! do |visit|
             visit.id               = @visit_id
             visit.attribution      = attribution
             visit.cookie_id        = @cookie_id
@@ -100,7 +100,7 @@ module Land
           p.click_id               = tracking_params['click_id']
           p.tiktok_pixel_cookie_id = tracking_params['tiktok_pixel_cookie_id']
           p.http_status            = status || response.status
-          p.visit_id               = @visit_id
+          p.visit_id               = @visit.id
           p.created_at             = current_time
           p.response_time          = (current_time - @start_time) * 1000
         end

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -87,10 +87,10 @@ module Land
         current_time = Time.now
 
         @pageview = Pageview.create do |p|
-          p.path                   = path || request.path.to_s
+          p.path                   = path || page_view_path || request.path.to_s
           p.http_method            = method || request.method
           p.mime_type              = request.media_type || request.format.to_s
-          p.query_string           = untracked_params.to_query
+          p.query_string           = untracked_params.to_query.presence || page_view_query_string
           p.request_id             = request.uuid
           p.click_id               = tracking_params['click_id']
           p.tiktok_pixel_cookie_id = tracking_params['tiktok_pixel_cookie_id']
@@ -99,6 +99,31 @@ module Land
           p.created_at             = current_time
           p.response_time          = (current_time - @start_time) * 1000
         end
+
+        maybe_update_visit_attribution
+
+        @pageview
+      end
+
+      def maybe_update_visit_attribution
+        return unless @visit && visit_attribution_empty? && page_view_query_string.present?
+
+        @visit.update!(attribution: attribution_from_page_view_query_string)
+      end
+
+      def attribution_from_page_view_query_string
+        return unless page_view_query_string.present?
+
+        params = Rack::Utils.parse_nested_query(page_view_query_string)
+        Attribution.lookup extract_tracking(params)
+      end
+
+      def page_view_query_string
+        request && request.params['page_view_query_string']
+      end
+
+      def page_view_path
+        request && request.params['page_view_path']
       end
 
       # This is invoked from Land::Action
@@ -226,6 +251,10 @@ module Land
              .reject { |k, _v| %w[attribution_id created_at].include?(k) }
              .values
              .any?
+      end
+
+      def visit_attribution_empty?
+        !attribution_values_present?(@visit)
       end
     end
   end

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -6,6 +6,7 @@ module Land
       attr_reader :pageview
 
       VISIT_ENDPOINT_REGEX = %r{^/api/v\d+/visit$}
+      PAGEVIEW_ENDPOINT_REGEX = %r{^/api/v\d+/tracking/page-view$}
 
       def track
         load
@@ -25,9 +26,13 @@ module Land
           maybe_set_visit_referer
           maybe_set_user_agent
           maybe_set_click_id
-
-          @visit&.save! if @visit&.changed?
         end
+
+        # When bots click links, we do not get cookies loaded, so no visit call is made
+        # This will set attribution if there is no visit call made
+        maybe_set_visit_attribution_from_pageview if controller.request.path =~ PAGEVIEW_ENDPOINT_REGEX
+
+        @visit&.save! if @visit&.changed?
       rescue StandardError => e
         # Here we are going to tag the span with the error if Datadog span
         # exists This is called safely to avoid errors in the case that Datadog
@@ -87,10 +92,10 @@ module Land
         current_time = Time.now
 
         @pageview = Pageview.create do |p|
-          p.path                   = path || page_view_path || request.path.to_s
+          p.path                   = path || request.path.to_s
           p.http_method            = method || request.method
           p.mime_type              = request.media_type || request.format.to_s
-          p.query_string           = untracked_params.to_query.presence || page_view_query_string
+          p.query_string           = untracked_params.to_query
           p.request_id             = request.uuid
           p.click_id               = tracking_params['click_id']
           p.tiktok_pixel_cookie_id = tracking_params['tiktok_pixel_cookie_id']
@@ -99,16 +104,12 @@ module Land
           p.created_at             = current_time
           p.response_time          = (current_time - @start_time) * 1000
         end
-
-        maybe_update_visit_attribution
-
-        @pageview
       end
 
-      def maybe_update_visit_attribution
+      def maybe_set_visit_attribution_from_pageview
         return unless @visit && visit_attribution_empty? && page_view_query_string.present?
 
-        @visit.update!(attribution: attribution_from_page_view_query_string)
+        @visit.attribution = attribution_from_page_view_query_string
       end
 
       def attribution_from_page_view_query_string

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -51,8 +51,7 @@ module Land
         return @visit_id if visit
 
         begin
-          @visit = Visit.create! do |visit|
-            visit.id               = @visit_id
+          @visit = Visit.where(visit_id: @visit_id).first_or_create do |visit|
             visit.attribution      = attribution
             visit.cookie_id        = @cookie_id
             visit.referer_id       = referer&.id
@@ -62,9 +61,9 @@ module Land
             visit.raw_query_string = referer_uri&.query
             visit.click_id         = tracking_params['click_id']
           end
+        rescue ActiveRecord::RecordNotUnique
           # This handles a race condition between the visit and other API requests
           # ex: page_views, events, feature_flags
-        rescue ActiveRecord::RecordNotUnique
           @visit = Visit.where(visit_id: @visit_id).first
         end
 

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.19'
+  VERSION = '0.1.20'
 end

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     Rails.application.routes.draw do
       get '/api/v1/test', to: 'api_tracker_test#call'
       post '/api/v1/visit', to: 'api_tracker_test#call'
+      post '/api/v1/tracking/page-view', to: 'api_tracker_test#call'
     end
   end
 
@@ -200,9 +201,6 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     let(:cookie_id) { SecureRandom.uuid }
     let(:visit_id) { SecureRandom.uuid }
 
-    before do
-    end
-
     it 'record visit does not throw an error' do
       allow(Land::Visit).to receive(:create)
         .and_raise(ActiveRecord::RecordNotUnique, 'Visit already exists')
@@ -235,6 +233,87 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     end
   end
 
+  context 'pageview arrives first' do
+    let(:cookie_id) { SecureRandom.uuid }
+    let(:visit_id) { SecureRandom.uuid }
+
+    it 'the attribution is parsed' do
+      post '/api/v1/tracking/page-view', params: {
+                                           cookie_id:,
+                                           visit_id:,
+                                           page_view_path: 'http://thedebtfreenurse.com/the-debt-free-nurse',
+                                           page_view_query_string: query_string,
+                                           page_view_mime_type: 'text/html',
+                                           page_view_http_method: 'GET',
+                                           page_view_http_status: '200'
+                                         },
+                                         as: :json
+
+      expect(Land::Visit.where(cookie_id:).count).to eq(1)
+
+      visit = Land::Visit.find_by(visit_id:)
+
+      expect(visit.click_id).to eq(nil)
+      expect(visit.raw_query_string).to eq(nil)
+      expect(visit.referer).to eq(nil)
+      expect(visit.unaltered_ingress_url).to eq(nil)
+
+      expect(visit.cookie_id).to eq(cookie_id)
+      expect(visit.visit_id).to eq(visit_id)
+      expect(visit.user_agent.user_agent).to eq('user agent missing')
+
+      expect(visit.attribution).to_not be_nil
+      expect(visit.attribution.campaign).to eq(utm_campaign)
+      expect(visit.attribution.content).to eq(utm_content)
+      expect(visit.attribution.medium).to eq(utm_medium)
+      expect(visit.attribution.source).to eq('instagram')
+      expect(visit.attribution.campaign_identifier).to eq(utm_campaign_id)
+      expect(visit.attribution.medium_identifier).to eq(utm_medium_id)
+      expect(visit.attribution.content_identifier).to eq(utm_content_id)
+    end
+
+    context 'and a visit arrives after' do
+      before(:each) do
+        post '/api/v1/tracking/page-view', params: {
+                                             cookie_id:,
+                                             visit_id:,
+                                             page_view_path: 'http://thedebtfreenurse.com/the-debt-free-nurse',
+                                             page_view_query_string: query_string,
+                                             page_view_mime_type: 'text/html',
+                                             page_view_http_method: 'GET',
+                                             page_view_http_status: '200'
+                                           },
+                                           as: :json
+      end
+
+      it 'updates attribution as expected' do
+        post "/api/v1/visit?#{query_string}", params: body,
+                                              as: :json
+
+        expect(Land::Visit.where(cookie_id:).count).to eq(1)
+
+        visit = Land::Visit.find_by(visit_id:)
+
+        expect(visit.cookie_id).to eq(cookie_id)
+        expect(visit.visit_id).to eq(visit_id)
+        expect(visit.referer.domain).to eq('veterandebtassistance.org')
+        expect(visit.user_agent.user_agent).to eq(user_agent)
+        expect(visit.unaltered_ingress_url).to eq(unaltered_ingress_url)
+        expect(visit.raw_query_string).to eq(query_string)
+        expect(visit.click_id).to eq(fbclid)
+        expect(visit.attribution).to_not be_nil
+
+        expect(visit.attribution.campaign).to eq(utm_campaign)
+        expect(visit.attribution.content).to eq(utm_content)
+        expect(visit.attribution.medium).to eq(utm_medium)
+        expect(visit.attribution.source).to eq('instagram')
+        expect(visit.attribution.campaign_identifier).to eq(utm_campaign_id)
+        expect(visit.attribution.medium_identifier).to eq(utm_medium_id)
+        expect(visit.attribution.content_identifier).to eq(utm_content_id)
+      end
+    end
+  end
+
   context 'unit tests' do
     let(:cookie_id) { SecureRandom.uuid }
     let(:visit_id) { SecureRandom.uuid }
@@ -246,6 +325,16 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
         expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to match('/api/v1121/visit')
         expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to_not match('/api/v1/visitX')
         expect(Land::Trackers::ApiTracker::VISIT_ENDPOINT_REGEX).to_not match('/apii/v1/visit')
+      end
+    end
+
+    describe 'PAGEVIEW_ENDPOINT_REGEX' do
+      it 'matches the correct endpoint' do
+        expect(Land::Trackers::ApiTracker::PAGEVIEW_ENDPOINT_REGEX).to be_a(Regexp)
+        expect(Land::Trackers::ApiTracker::PAGEVIEW_ENDPOINT_REGEX).to match('/api/v1/tracking/page-view')
+        expect(Land::Trackers::ApiTracker::PAGEVIEW_ENDPOINT_REGEX).to match('/api/v1121/tracking/page-view')
+        expect(Land::Trackers::ApiTracker::PAGEVIEW_ENDPOINT_REGEX).to_not match('/api/v1/tracking/page-viewX')
+        expect(Land::Trackers::ApiTracker::PAGEVIEW_ENDPOINT_REGEX).to_not match('/apii/v1/tracking/page-view')
       end
     end
   end


### PR DESCRIPTION
Allows the APITracker to set visit.attribution on a `/api/v1/tracking/page-view` call.


Edit(Kyle) There are further changes that mitigate an error seen on race condition for visit creation. moving to `#first_or_create!` ensures we only get `ActiveRecord::RecordNotUnique` on visit creation, on race condition (using `#create!`) it would raise `AcriveRecord::RecordInvalid: Visit has already been taken` due to the non-unique visit_id. 

Error that was in lab:
<img width="769" alt="Screenshot 2025-06-13 at 4 35 38 PM" src="https://github.com/user-attachments/assets/89f32e44-3136-4007-bae7-3b930584a489" />

After above change:
<img width="1367" alt="Screenshot 2025-06-13 at 4 36 19 PM" src="https://github.com/user-attachments/assets/1167d92c-c6d8-4022-b409-5af7d7b48c73" />
