### PR TITLE
[ENG-2764] Feat/Set User Agent Attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gemspec
 
 # gem "pry", github: "pry/pry"
 
+gem "browser", require: "browser/browser"
+
 group :development, :test do
   gem "combustion"
   gem "pry-rails"

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -209,6 +209,15 @@ module Land
           @user_agent.update(user_agent_type: UserAgentType[user_agent_type])
         end
 
+        browser = ::Browser.new(user_agent)
+
+        @user_agent.update(
+          browser: Browser[browser.name],
+          device: Device[browser.device.name],
+          platform: Platform[browser.platform.name],
+          browser_version: browser.version
+        )
+
         @user_agent
       end
     end

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.21'
+  VERSION = '0.1.22'
 end

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.visit_id).to eq(visit_id)
       expect(visit.referer.domain).to eq('veterandebtassistance.org')
       expect(visit.user_agent.user_agent).to eq(user_agent)
+      expect(visit.user_agent.device).to eq('Unknown')
+      expect(visit.user_agent.platform).to eq('Windows')
+      expect(visit.user_agent.browser).to eq('Chrome')
+      expect(visit.user_agent.browser_version).to eq('98')
+
       expect(visit.unaltered_ingress_url).to eq(unaltered_ingress_url)
       expect(visit.raw_query_string).to eq(query_string)
       expect(visit.click_id).to eq(fbclid)
@@ -133,6 +138,11 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.visit_id).to eq(visit_id)
       expect(visit.referer).to eq(nil)
       expect(visit.user_agent.user_agent).to eq('user agent missing')
+      expect(visit.user_agent.device).to eq('Unknown')
+      expect(visit.user_agent.platform).to eq('Other')
+      expect(visit.user_agent.browser).to eq('Generic Browser')
+      expect(visit.user_agent.browser_version).to eq('0')
+
       expect(visit.unaltered_ingress_url).to eq(nil)
       expect(visit.raw_query_string).to eq(nil)
       expect(visit.click_id).to eq(nil)
@@ -170,6 +180,11 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.visit_id).to eq(visit_id)
       expect(visit.referer.domain).to eq('veterandebtassistance.org')
       expect(visit.user_agent.user_agent).to eq(user_agent)
+      expect(visit.user_agent.device).to eq('Unknown')
+      expect(visit.user_agent.platform).to eq('Windows')
+      expect(visit.user_agent.browser).to eq('Chrome')
+      expect(visit.user_agent.browser_version).to eq('98')
+
       expect(visit.unaltered_ingress_url).to eq(unaltered_ingress_url)
       expect(visit.raw_query_string).to eq(query_string)
       expect(visit.click_id).to eq(fbclid)
@@ -263,6 +278,10 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.cookie_id).to eq(cookie_id)
       expect(visit.visit_id).to eq(visit_id)
       expect(visit.user_agent.user_agent).to eq('user agent missing')
+      expect(visit.user_agent.device).to eq('Unknown')
+      expect(visit.user_agent.platform).to eq('Other')
+      expect(visit.user_agent.browser).to eq('Generic Browser')
+      expect(visit.user_agent.browser_version).to eq('0')
 
       expect(visit.attribution).to_not be_nil
       expect(visit.attribution.campaign).to eq(utm_campaign)
@@ -300,6 +319,11 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
         expect(visit.visit_id).to eq(visit_id)
         expect(visit.referer.domain).to eq('veterandebtassistance.org')
         expect(visit.user_agent.user_agent).to eq(user_agent)
+        expect(visit.user_agent.device).to eq('Unknown')
+        expect(visit.user_agent.platform).to eq('Windows')
+        expect(visit.user_agent.browser).to eq('Chrome')
+        expect(visit.user_agent.browser_version).to eq('98')
+
         expect(visit.unaltered_ingress_url).to eq(unaltered_ingress_url)
         expect(visit.raw_query_string).to eq(query_string)
         expect(visit.click_id).to eq(fbclid)


### PR DESCRIPTION
This PR adds the gem [browser](https://github.com/fnando/browser) to get device information. It also updates the version, specs, and logic in `lib/land/trackers/api_tracker.rb#user_agent` method to set the user agent attributes:

- browser
- device
- platform
- browser_version