### PR TITLE
feat(app): rescue activerecord recordinvalid

### DIFF
--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -37,9 +37,12 @@ module Land
 
         begin
           Cookie.find_or_create_by(cookie_id: @cookie_id)
-        rescue ActiveRecord::RecordInvalid,
-               ActiveRecord::RecordNotUnique
+        rescue ActiveRecord::RecordNotUnique
           retry
+        rescue ActiveRecord::RecordInvalid => e
+          retry if e.message =~ /Validation failed: Cookie has already been taken/
+
+          raise e
         end
       end
 
@@ -79,9 +82,12 @@ module Land
           maybe_set_visit_attribution_from_pageview if controller.request.path =~ PAGEVIEW_ENDPOINT_REGEX
 
           @visit&.save! if @visit&.changed?
-        rescue ActiveRecord::RecordInvalid,
-               ActiveRecord::RecordNotUnique
+        rescue ActiveRecord::RecordNotUnique
           retry
+        rescue ActiveRecord::RecordInvalid => e
+          retry if e.message =~ /Validation failed: Visit has already been taken/
+
+          raise e
         end
 
         @visit.visit_id

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -37,7 +37,8 @@ module Land
 
         begin
           Cookie.find_or_create_by(cookie_id: @cookie_id)
-        rescue ActiveRecord::RecordNotUnique
+        rescue ActiveRecord::RecordInvalid,
+               ActiveRecord::RecordNotUnique
           retry
         end
       end
@@ -78,7 +79,8 @@ module Land
           maybe_set_visit_attribution_from_pageview if controller.request.path =~ PAGEVIEW_ENDPOINT_REGEX
 
           @visit&.save! if @visit&.changed?
-        rescue ActiveRecord::RecordNotUnique
+        rescue ActiveRecord::RecordInvalid,
+               ActiveRecord::RecordNotUnique
           retry
         end
 

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -40,7 +40,7 @@ module Land
         rescue ActiveRecord::RecordNotUnique
           retry
         rescue ActiveRecord::RecordInvalid => e
-          retry if e.message =~ /Validation failed: Cookie has already been taken/
+          retry if e.message == 'Validation failed: Cookie has already been taken'
 
           raise e
         end
@@ -49,48 +49,44 @@ module Land
       # Overriding record_visit method as we set the visit id from the API param,
       # so we have to check the Land::Visit does not exist
       def record_visit
-        Visit.transaction do
-          @visit = Visit.find_or_initialize_by(visit_id: @visit_id) do |visit|
-            visit.attribution      = attribution
-            visit.cookie_id        = @cookie_id
-            visit.referer_id       = referer&.id
-            visit.user_agent_id    = user_agent&.id
-            visit.ip_address       = remote_ip
-            visit.domain_id        = request_domain&.id
-            visit.raw_query_string = referer_uri&.query
-            visit.click_id         = tracking_params['click_id']
-          end
-
-          # Api request race conditions mean that the visit may be created on a call
-          # that is not the visit call. Query strings are passed from the front end
-          # visit API call. If the visit is created on a different call, the query
-          # string will be updated whenever the visit API call is completed.
-
-          # Here we only invoke the visit attribution update if the request is a
-          # visit API call
-          if controller.request.path =~ VISIT_ENDPOINT_REGEX
-            maybe_set_raw_query_string
-            maybe_set_unaltered_ingress_url
-            maybe_set_visit_attribution
-            maybe_set_visit_referer
-            maybe_set_user_agent
-            maybe_set_click_id
-          end
-
-          # When bots click links, we do not get cookies loaded, so no visit call is made
-          # This will set attribution if there is no visit call made
-          maybe_set_visit_attribution_from_pageview if controller.request.path =~ PAGEVIEW_ENDPOINT_REGEX
-
-          @visit&.save! if @visit&.changed?
-        rescue ActiveRecord::RecordNotUnique
-          retry
-        rescue ActiveRecord::RecordInvalid => e
-          retry if e.message =~ /Validation failed: Visit has already been taken/
-
-          raise e
+        @visit = Visit.find_or_initialize_by(visit_id: @visit_id) do |visit|
+          visit.attribution = attribution
+          visit.cookie_id        = @cookie_id
+          visit.referer_id       = referer&.id
+          visit.user_agent_id    = user_agent&.id
+          visit.ip_address       = remote_ip
+          visit.domain_id        = request_domain&.id
+          visit.raw_query_string = referer_uri&.query
+          visit.click_id         = tracking_params['click_id']
         end
 
-        @visit.visit_id
+        # Api request race conditions mean that the visit may be created on a call
+        # that is not the visit call. Query strings are passed from the front end
+        # visit API call. If the visit is created on a different call, the query
+        # string will be updated whenever the visit API call is completed.
+
+        # Here we only invoke the visit attribution update if the request is a
+        # visit API call
+        if controller.request.path =~ VISIT_ENDPOINT_REGEX
+          maybe_set_raw_query_string
+          maybe_set_unaltered_ingress_url
+          maybe_set_visit_attribution
+          maybe_set_visit_referer
+          maybe_set_user_agent
+          maybe_set_click_id
+        end
+
+        # When bots click links, we do not get cookies loaded, so no visit call is made
+        # This will set attribution if there is no visit call made
+        maybe_set_visit_attribution_from_pageview if controller.request.path =~ PAGEVIEW_ENDPOINT_REGEX
+
+        @visit&.save! if @visit&.changed?
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      rescue ActiveRecord::RecordInvalid => e
+        retry if e.message == 'Validation failed: Visit has already been taken'
+
+        raise e
       end
 
       def maybe_set_raw_query_string

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.22'
+  VERSION = '0.1.23'
 end

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.referer).to eq(nil)
       expect(visit.user_agent.user_agent).to eq('user agent missing')
       expect(visit.user_agent.device).to eq('Unknown')
-      expect(visit.user_agent.platform).to eq('Other')
-      expect(visit.user_agent.browser).to eq('Generic Browser')
+      expect(visit.user_agent.platform).to eq('Unknown')
+      expect(visit.user_agent.browser).to eq('Unknown Browser')
       expect(visit.user_agent.browser_version).to eq('0')
 
       expect(visit.unaltered_ingress_url).to eq(nil)
@@ -216,7 +216,7 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     let(:cookie_id) { SecureRandom.uuid }
     let(:visit_id) { SecureRandom.uuid }
 
-    it 'record visit does not throw an error' do
+    it 'record visit rescues and retries on ActiveRecord::RecordNotUnique error' do
       allow(Land::Visit).to receive(:create)
         .and_raise(ActiveRecord::RecordNotUnique, 'Visit already exists')
         .and_call_original
@@ -232,10 +232,43 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
                                             as: :json
     end
 
-    it 'load does not throw error on cookie race condition' do
+    it 'record visit rescues and retries on ActiveRecord::RecordInvalid error' do
+      allow(Land::Visit).to receive(:create)
+        .and_raise(ActiveRecord::RecordInvalid, 'Visit already exists')
+        .and_call_original
+
+      # this is asserting that the `record_visit` call does not throw an error,
+      # as this method that is called after the `record_visit` call
+      expect_any_instance_of(Land::Trackers::ApiTracker)
+        .to receive(:maybe_set_raw_query_string)
+        .and_call_original
+
+      # visit call
+      post "/api/v1/visit?#{query_string}", params: body,
+                                            as: :json
+    end
+
+    it 'load does not throw error on ActiveRecord::RecordNotUnique error' do
       allow(Land::Cookie)
         .to receive_message_chain(:where, :first_or_create)
         .and_raise(ActiveRecord::RecordNotUnique, 'Cookie already exists')
+        .and_return([])
+
+      # this is asserting that the `load` call does not throw an error,
+      # as this method that is called after the `load` call
+      expect_any_instance_of(Land::Trackers::ApiTracker)
+        .to receive(:record_visit)
+        .and_call_original
+
+      # visit call
+      post "/api/v1/visit?#{query_string}", params: body,
+                                            as: :json
+    end
+
+    it 'load does not throw error on ActiveRecord::RecordInvalid error' do
+      allow(Land::Cookie)
+        .to receive_message_chain(:where, :first_or_create)
+        .and_raise(ActiveRecord::RecordInvalid, 'Cookie already exists')
         .and_return([])
 
       # this is asserting that the `load` call does not throw an error,
@@ -279,8 +312,8 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.visit_id).to eq(visit_id)
       expect(visit.user_agent.user_agent).to eq('user agent missing')
       expect(visit.user_agent.device).to eq('Unknown')
-      expect(visit.user_agent.platform).to eq('Other')
-      expect(visit.user_agent.browser).to eq('Generic Browser')
+      expect(visit.user_agent.platform).to eq('Unknown')
+      expect(visit.user_agent.browser).to eq('Unknown Browser')
       expect(visit.user_agent.browser_version).to eq('0')
 
       expect(visit.attribution).to_not be_nil

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -217,69 +217,111 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     let(:visit_id) { SecureRandom.uuid }
 
     it 'record visit rescues and retries on ActiveRecord::RecordNotUnique error' do
-      allow(Land::Visit).to receive(:create)
-        .and_raise(ActiveRecord::RecordNotUnique, 'Visit already exists')
-        .and_call_original
+      expect(Land::Visit.count).to eq(0)
 
-      # this is asserting that the `record_visit` call does not throw an error,
-      # as this method that is called after the `record_visit` call
-      expect_any_instance_of(Land::Trackers::ApiTracker)
-        .to receive(:maybe_set_raw_query_string)
-        .and_call_original
+      save_calls = 0
+      allow_any_instance_of(Land::Visit).to receive(:save!) do |visit|
+        save_calls += 1
+        raise ActiveRecord::RecordNotUnique if save_calls == 1
+
+        # Mimic the original implementation
+        expect(visit.persisted?).to eq(false)
+        expect(visit.valid?).to eq(true)
+        expect(visit.changed?).to eq(true)
+        visit.save
+        expect(visit.persisted?).to eq(true)
+      end
 
       # visit call
       post "/api/v1/visit?#{query_string}", params: body,
                                             as: :json
+
+      expect(save_calls).to eq(2)
+      expect(Land::Visit.count).to eq(1)
+      expect(Land::Visit.first.visit_id).to eq(visit_id)
     end
 
     it 'record visit rescues and retries on ActiveRecord::RecordInvalid error' do
-      allow(Land::Visit).to receive(:create)
-        .and_raise(ActiveRecord::RecordInvalid, 'Visit already exists')
-        .and_call_original
+      expect(Land::Visit.count).to eq(0)
 
-      # this is asserting that the `record_visit` call does not throw an error,
-      # as this method that is called after the `record_visit` call
-      expect_any_instance_of(Land::Trackers::ApiTracker)
-        .to receive(:maybe_set_raw_query_string)
-        .and_call_original
+      save_calls = 0
+      allow_any_instance_of(Land::Visit).to receive(:save!) do |visit|
+        save_calls += 1
+
+        if save_calls == 1
+          visit.errors.add(:base, 'Visit has already been taken')
+          raise ActiveRecord::RecordInvalid.new(visit)
+        end
+
+        # Mimic the original implementation
+        expect(visit.persisted?).to eq(false)
+        expect(visit.valid?).to eq(true)
+        expect(visit.changed?).to eq(true)
+        visit.save
+        expect(visit.persisted?).to eq(true)
+      end
 
       # visit call
       post "/api/v1/visit?#{query_string}", params: body,
                                             as: :json
+
+      expect(save_calls).to eq(2)
+      expect(Land::Visit.count).to eq(1)
+      expect(Land::Visit.first.visit_id).to eq(visit_id)
     end
 
     it 'load does not throw error on ActiveRecord::RecordNotUnique error' do
-      allow(Land::Cookie)
-        .to receive_message_chain(:where, :first_or_create)
-        .and_raise(ActiveRecord::RecordNotUnique, 'Cookie already exists')
-        .and_return([])
+      expect(Land::Cookie.count).to eq(0)
 
-      # this is asserting that the `load` call does not throw an error,
-      # as this method that is called after the `load` call
-      expect_any_instance_of(Land::Trackers::ApiTracker)
-        .to receive(:record_visit)
-        .and_call_original
+      find_or_create_calls = 0
+      allow(Land::Cookie).to receive(:find_or_create_by) do |attributes, &block|
+        find_or_create_calls += 1
+        raise ActiveRecord::RecordNotUnique if find_or_create_calls == 1
+
+        expect(Land::Cookie.count).to eq(0)
+
+        # this mirrors the implementation of Land::Cookie.find_or_create_by
+        # source code: https://github.com/rails/rails/blob/b0405f820a4acf3fae85044c71a819967fd59967/activerecord/lib/active_record/relation.rb#L231
+        Land::Cookie.find_by(attributes) || Land::Cookie.create_or_find_by(attributes, &block)
+      end
 
       # visit call
       post "/api/v1/visit?#{query_string}", params: body,
                                             as: :json
+
+      expect(find_or_create_calls).to eq(2)
+
+      expect(Land::Cookie.count).to eq(1)
+      expect(Land::Cookie.first.cookie_id).to eq(cookie_id)
     end
 
     it 'load does not throw error on ActiveRecord::RecordInvalid error' do
-      allow(Land::Cookie)
-        .to receive_message_chain(:where, :first_or_create)
-        .and_raise(ActiveRecord::RecordInvalid, 'Cookie already exists')
-        .and_return([])
+      expect(Land::Cookie.count).to eq(0)
 
-      # this is asserting that the `load` call does not throw an error,
-      # as this method that is called after the `load` call
-      expect_any_instance_of(Land::Trackers::ApiTracker)
-        .to receive(:record_visit)
-        .and_call_original
+      find_or_create_calls = 0
+      allow(Land::Cookie).to receive(:find_or_create_by) do |attributes, &block|
+        find_or_create_calls += 1
+
+        if find_or_create_calls == 1
+          cookie = Land::Cookie.new(cookie_id: cookie_id)
+          cookie.errors.add(:base, 'Cookie has already been taken')
+          raise ActiveRecord::RecordInvalid.new(cookie)
+        end
+
+        expect(Land::Cookie.count).to eq(0)
+
+        # this mirrors the implementation of Land::Cookie.find_or_create_by
+        # source code: https://github.com/rails/rails/blob/b0405f820a4acf3fae85044c71a819967fd59967/activerecord/lib/active_record/relation.rb#L231
+        Land::Cookie.find_by(attributes) || Land::Cookie.create_or_find_by(attributes, &block)
+      end
 
       # visit call
       post "/api/v1/visit?#{query_string}", params: body,
                                             as: :json
+
+      expect(find_or_create_calls).to eq(2)
+      expect(Land::Cookie.count).to eq(1)
+      expect(Land::Cookie.first.cookie_id).to eq(cookie_id)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,6 @@ Combustion.initialize! :active_record,
                        load_schema: false,
                        database_migrate: false
 
-
 require 'land'
 
 Land.configure do |config|
@@ -41,8 +40,6 @@ Land.configure do |config|
   # Timeout before a new visit is created
   config.visit_timeout = 1.hour
 end
-
-
 
 require 'spec_helper'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -84,7 +84,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+    config.default_formatter = 'doc'
   end
 
   # Print the 10 slowest examples and example groups at the
@@ -112,53 +112,51 @@ RSpec.configure do |config|
     LookupBy.disable
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
This PR also rescues `ActiveRecord::RecordInvalid`, as this is what is raised on `#find_or_initialize_by` when the record with the provided UUID already exists. This resolves the validation error that was seen in `lab`.