### PR TITLE
Task / Update Gem Versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.3.0
+ruby 3.3.8
 nodejs 20.3.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.1.2
+ruby 3.3.0
 nodejs 20.3.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.3.8
+ruby 3.4.2
 nodejs 20.3.1

--- a/land.gemspec
+++ b/land.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activerecord", " > 4.0.0"
   gem.add_dependency "lookup_by",    "~> 0.12.0"
   gem.add_dependency "browser",      "~> 6.2.0"
+  gem.add_dependency "mutex_m",    "~> 0.3.0"
 
   gem.add_development_dependency "pg"
   gem.add_development_dependency "rake"

--- a/land.gemspec
+++ b/land.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "addressable"
   gem.add_dependency "activerecord", " > 4.0.0"
   gem.add_dependency "lookup_by",    "~> 0.12.0"
+  gem.add_dependency "browser",      "~> 6.2.0"
 
   gem.add_development_dependency "pg"
   gem.add_development_dependency "rake"

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.24'
+  VERSION = '0.1.23'
 end

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.22'
+  VERSION = '0.1.24'
 end

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.referer).to eq(nil)
       expect(visit.user_agent.user_agent).to eq('user agent missing')
       expect(visit.user_agent.device).to eq('Unknown')
-      expect(visit.user_agent.platform).to eq('Other')
-      expect(visit.user_agent.browser).to eq('Generic Browser')
+      expect(visit.user_agent.platform).to eq('Unknown')
+      expect(visit.user_agent.browser).to eq('Unknown Browser')
       expect(visit.user_agent.browser_version).to eq('0')
 
       expect(visit.unaltered_ingress_url).to eq(nil)
@@ -279,8 +279,8 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.visit_id).to eq(visit_id)
       expect(visit.user_agent.user_agent).to eq('user agent missing')
       expect(visit.user_agent.device).to eq('Unknown')
-      expect(visit.user_agent.platform).to eq('Other')
-      expect(visit.user_agent.browser).to eq('Generic Browser')
+      expect(visit.user_agent.platform).to eq('Unknown')
+      expect(visit.user_agent.browser).to eq('Unknown Browser')
       expect(visit.user_agent.browser_version).to eq('0')
 
       expect(visit.attribution).to_not be_nil


### PR DESCRIPTION
This PR updates:

- Update ruby version from `3.1.2` to `3.4.2`
- Explicitly set `browser` version to `6.2.0`
- Add `mutex_m` to dependencies for rails `3.4.2` update
- Update land version to `0.1.23`