### PR TITLE
Task/tracker type config

### DIFF
--- a/app/models/land/visit.rb
+++ b/app/models/land/visit.rb
@@ -14,6 +14,15 @@ module Land
 
     validates :visit_id, presence: true, uniqueness: true
 
+    before_save do
+      tracker_class = caller.find{ |l| l.include?("Tracker") }&.split(' ')&.last&.split('#')&.first
+      # Attempt to add metadata to the active Datadog span if it exists.
+      Datadog::Tracing.active_span&.set_tag('visit_save', tracker_class:) if defined?(Datadog::Tracing) && Datadog::Tracing.respond_to?(:active_span)
+    rescue StandardError => e
+      # Rescue everything to avoid breaking the save.
+      nil
+    end
+
     after_initialize do
       self.id ||= SecureRandom.uuid
     end

--- a/lib/land/config.rb
+++ b/lib/land/config.rb
@@ -5,12 +5,16 @@ module Land
     ALLOWED_NEW_VISIT_REASONS = %w[referer_changed? attribution_changed? user_agent_changed? visit_stale?]
     attr_reader :enabled, :secure_cookie, :identify_crawlers, :logger
 
-    attr_writer :blank_user_agent_string
+    attr_writer :blank_user_agent_string, :api_tracking_only
     attr_writer :schema, :untracked_ips, :untracked_paths
 
     def initialize
       @enabled = false
       @secure_cookie = false
+    end
+
+    def api_tracking_only
+      @api_tracking_only ||= false
     end
 
     def blank_user_agent_string

--- a/lib/land/config.rb
+++ b/lib/land/config.rb
@@ -5,12 +5,16 @@ module Land
     ALLOWED_NEW_VISIT_REASONS = %w[referer_changed? attribution_changed? user_agent_changed? visit_stale?]
     attr_reader :enabled, :secure_cookie, :identify_crawlers
 
-    attr_writer :blank_user_agent_string
+    attr_writer :blank_user_agent_string, :api_tracking_only
     attr_writer :schema, :untracked_ips, :untracked_paths
 
     def initialize
       @enabled = false
       @secure_cookie = false
+    end
+
+    def api_tracking_only
+      @api_tracking_only ||= false
     end
 
     def blank_user_agent_string

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -112,8 +112,8 @@ module Land
         # override
         type = 'user' if controller.request.query_parameters.with_indifferent_access.slice(*TRACKING_KEYS).any?
 
-        # match on versioned APIs, which serve the frontend
-        type = 'api' if controller.request.path =~ %r{^/api/v}
+        # match on versioned APIs, which serve the frontend, or all requests if configured for api tracking only
+        type = 'api' if controller.request.path =~ %r{^/api/v} || Land.config.api_tracking_only
 
         "Land::Trackers::#{type.classify}Tracker".constantize.new(controller)
       end


### PR DESCRIPTION
* Adds config setting for "api_tracking_only"
* Adds logging the tracker type to datadog 

The logging for tracker type can/should be removed after we monitor this in prod. It's only being placed here for debugging purposes.