### PR TITLE
[ENG-3218] Feat: land visit post visit at timestamp set on POST /api/v1/visit call

### DIFF
--- a/db/migrate/20251017171657_add_post_visit_at_to_land_visits.rb
+++ b/db/migrate/20251017171657_add_post_visit_at_to_land_visits.rb
@@ -1,0 +1,5 @@
+class AddPostVisitAtToLandVisits < ActiveRecord::Migration[7.1]
+  def change
+    add_column 'land.visits', :post_visit_at, :datetime
+  end
+end

--- a/db/migrate/20251017171657_add_post_visit_at_to_land_visits.rb
+++ b/db/migrate/20251017171657_add_post_visit_at_to_land_visits.rb
@@ -1,5 +1,5 @@
 class AddPostVisitAtToLandVisits < ActiveRecord::Migration[7.1]
   def change
-    add_column 'land.visits', :post_visit_at, :datetime
+    add_column 'land.visits', :post_visit_at, :timestamptz
   end
 end

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -65,6 +65,7 @@ module Land
         # Here we only invoke the visit attribution update if the request is a
         # visit API call
         if controller.request.path =~ VISIT_ENDPOINT_REGEX
+          set_post_visit_at
           maybe_set_raw_query_string
           maybe_set_unaltered_ingress_url
           maybe_set_visit_attribution
@@ -84,6 +85,12 @@ module Land
         retry if e.message == 'Validation failed: Visit has already been taken'
 
         raise e
+      end
+
+      def set_post_visit_at
+        return if @visit.post_visit_at.present?
+
+        @visit.post_visit_at = Time.now
       end
 
       def maybe_set_raw_query_string
@@ -250,7 +257,7 @@ module Land
         dark_mode = color_preference['is_dark_mode']
         light_mode = color_preference['is_light_mode']
         no_preference = color_preference['is_no_preference']
-      
+
         BrowserColorPreference.find_or_initialize_by(
           dark_mode: dark_mode,
           light_mode: light_mode,

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -1320,7 +1320,7 @@ CREATE TABLE land.visits (
     domain_id integer,
     unaltered_ingress_url text,
     click_id text,
-    post_visit_at timestamp(6) without time zone
+    post_visit_at timestamp with time zone
 );
 
 

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -1106,16 +1106,16 @@ ALTER SEQUENCE land.referers_referer_id_seq OWNED BY land.referers.referer_id;
 --
 
 CREATE VIEW land.response_times_by_path AS
- SELECT agg.path_id,
-    agg.path,
-    agg."avg response time (ms)"
+ SELECT path_id,
+    path,
+    "avg response time (ms)"
    FROM ( SELECT p.path_id,
             p.path,
             round(avg(pv.response_time), 3) AS "avg response time (ms)"
            FROM (land.pageviews pv
              JOIN land.paths p USING (path_id))
           GROUP BY p.path_id, p.path) agg
-  ORDER BY agg."avg response time (ms)" DESC;
+  ORDER BY "avg response time (ms)" DESC;
 
 
 --
@@ -1319,7 +1319,8 @@ CREATE TABLE land.visits (
     raw_query_string text,
     domain_id integer,
     unaltered_ingress_url text,
-    click_id text
+    click_id text,
+    post_visit_at timestamp(6) without time zone
 );
 
 
@@ -3017,6 +3018,7 @@ ALTER TABLE ONLY land.visits
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251017171657'),
 ('20250922220507'),
 ('20250922195113'),
 ('20241218175001'),

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -107,7 +107,9 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
 
       expect(visit.cookie_id).to eq(cookie_id)
       expect(visit.visit_id).to eq(visit_id)
-      expect(visit.referer.domain).to eq('veterandebtassistance.org')
+      expect(visit.post_visit_at).to_not be_nil
+      expect(visit.post_visit_at).to be_a(ActiveSupport::TimeWithZone)
+
       expect(visit.user_agent.user_agent).to eq(user_agent)
       expect(visit.user_agent.user_agent_type).to eq('user')
       expect(visit.user_agent.device).to eq('Unknown')
@@ -174,6 +176,7 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
 
       expect(visit.cookie_id).to eq(cookie_id)
       expect(visit.visit_id).to eq(visit_id)
+      expect(visit.post_visit_at).to be_nil
       expect(visit.referer).to eq(nil)
       expect(visit.user_agent.user_agent).to eq('user agent missing')
       expect(visit.user_agent.user_agent_type).to eq('user')
@@ -221,6 +224,8 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.cookie_id).to eq(cookie_id)
       expect(visit.visit_id).to eq(visit_id)
       expect(visit.referer.domain).to eq('veterandebtassistance.org')
+      expect(visit.post_visit_at).to_not be_nil
+      expect(visit.post_visit_at).to be_a(ActiveSupport::TimeWithZone)
       expect(visit.user_agent.user_agent).to eq(user_agent)
       expect(visit.user_agent.user_agent_type).to eq('user')
       expect(visit.user_agent.device).to eq('Unknown')


### PR DESCRIPTION
See above.


Tests:
<img width="2551" height="1369" alt="Screenshot 2025-10-17 at 12 52 43 PM" src="https://github.com/user-attachments/assets/8feee9d8-fbd2-4760-915c-15c178cbcc25" />

