### PR TITLE
[ENG-3220] Feat: remove visit id default generation generation

### DIFF
--- a/app/models/land/visit.rb
+++ b/app/models/land/visit.rb
@@ -13,9 +13,5 @@ module Land
     has_many :pageviews, dependent: :destroy
 
     validates :visit_id, presence: true, uniqueness: true
-
-    after_initialize do
-      self.id ||= SecureRandom.uuid
-    end
   end
 end

--- a/db/migrate/20251020190607_remove_land_visit_id_column_default.rb
+++ b/db/migrate/20251020190607_remove_land_visit_id_column_default.rb
@@ -1,0 +1,5 @@
+class RemoveLandVisitIdColumnDefault < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default 'land.visits', :visit_id, nil
+  end
+end

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -1307,7 +1307,7 @@ ALTER SEQUENCE land.user_agents_user_agent_id_seq OWNED BY land.user_agents.user
 --
 
 CREATE TABLE land.visits (
-    visit_id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    visit_id uuid NOT NULL,
     cookie_id uuid NOT NULL,
     user_agent_id integer NOT NULL,
     attribution_id integer NOT NULL,
@@ -3018,6 +3018,7 @@ ALTER TABLE ONLY land.visits
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251020190607'),
 ('20251017171657'),
 ('20250922220507'),
 ('20250922195113'),


### PR DESCRIPTION
Removes visit_id creation if not supplied via the API.