### PR TITLE
Feat/land visits purpose header field

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,8 +4,8 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
-rails db:reset
+bundle exec rails db:reset
 
-rspec
+bundle exec rspec
 
 # Do any other automated setup that you need to do here

--- a/db/migrate/20260204204804_add_purpose_header_to_land_visits.rb
+++ b/db/migrate/20260204204804_add_purpose_header_to_land_visits.rb
@@ -1,0 +1,6 @@
+class AddPurposeHeaderToLandVisits < ActiveRecord::Migration[7.1]
+  def change
+    add_column 'land.visits', :purpose_header, :string, null: true
+    add_index 'land.visits', :purpose_header
+  end
+end

--- a/db/migrate/20260204204804_add_purpose_header_to_land_visits.rb
+++ b/db/migrate/20260204204804_add_purpose_header_to_land_visits.rb
@@ -1,6 +1,9 @@
 class AddPurposeHeaderToLandVisits < ActiveRecord::Migration[7.1]
   def change
-    add_column 'land.visits', :purpose_header, :string, null: true
-    add_index 'land.visits', :purpose_header
+    add_column 'land.visits', :http_purpose_header, :string, null: true
+    add_index 'land.visits', :http_purpose_header
+
+    add_column 'land.visits', :http_sec_purpose_header, :string, null: true
+    add_index 'land.visits', :http_sec_purpose_header
   end
 end

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -55,6 +55,7 @@ module Land
           visit.domain_id        = request_domain&.id
           visit.raw_query_string = referer_uri&.query
           visit.click_id         = tracking_params['click_id']
+          visit.purpose_header   = purpose_header if purpose_header
         end
 
         # Api request race conditions mean that the visit may be created on a call
@@ -85,6 +86,24 @@ module Land
         retry if e.message == 'Validation failed: Visit has already been taken'
 
         raise e
+      end
+
+      # The purpose header is used to identify prefetch requests, which we need
+      # to account for in order for our data to be accurate.
+      def purpose_header
+        prefetch_header = %w[HTTP_SEC_PURPOSE HTTP_PURPOSE].map do |header|
+          return request.headers[header] if request.headers[header]&.to_s&.match?(/prefetch/i)
+
+          nil
+        end.compact.first
+
+        return prefetch_header if prefetch_header
+
+        %w[HTTP_SEC_PURPOSE HTTP_PURPOSE].map do |header|
+          return request.headers[header] if request.headers[header]&.to_s
+
+          nil
+        end.compact.first
       end
 
       def set_post_visit_at

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -55,8 +55,8 @@ module Land
           visit.domain_id               = request_domain&.id
           visit.raw_query_string        = referer_uri&.query
           visit.click_id                = tracking_params['click_id']
-          visit.http_purpose_header     = request.headers['HTTP_PURPOSE']
-          visit.http_sec_purpose_header = request.headers['HTTP_SEC_PURPOSE']
+          visit.http_purpose_header     = request.headers['HTTP_PURPOSE']     || request.headers['http_purpose']
+          visit.http_sec_purpose_header = request.headers['HTTP_SEC_PURPOSE'] || request.headers['http_sec_purpose']
         end
 
         # Api request race conditions mean that the visit may be created on a call
@@ -87,24 +87,6 @@ module Land
         retry if e.message == 'Validation failed: Visit has already been taken'
 
         raise e
-      end
-
-      # The purpose header is used to identify prefetch requests, which we need
-      # to account for in order for our data to be accurate.
-      def purpose_header
-        prefetch_header = %w[HTTP_SEC_PURPOSE HTTP_PURPOSE].map do |header|
-          return request.headers[header] if request.headers[header]&.to_s&.match?(/prefetch/i)
-
-          nil
-        end.compact.first
-
-        return prefetch_header if prefetch_header
-
-        %w[HTTP_SEC_PURPOSE HTTP_PURPOSE].map do |header|
-          return request.headers[header] if request.headers[header]&.to_s
-
-          nil
-        end.compact.first
       end
 
       def set_post_visit_at

--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -47,15 +47,16 @@ module Land
       # so we have to check the Land::Visit does not exist
       def record_visit
         @visit = Visit.find_or_initialize_by(visit_id: @visit_id) do |visit|
-          visit.attribution = attribution
-          visit.cookie_id        = @cookie_id
-          visit.referer_id       = referer&.id
-          visit.user_agent_id    = user_agent&.id
-          visit.ip_address       = remote_ip
-          visit.domain_id        = request_domain&.id
-          visit.raw_query_string = referer_uri&.query
-          visit.click_id         = tracking_params['click_id']
-          visit.purpose_header   = purpose_header if purpose_header
+          visit.attribution             = attribution
+          visit.cookie_id               = @cookie_id
+          visit.referer_id              = referer&.id
+          visit.user_agent_id           = user_agent&.id
+          visit.ip_address              = remote_ip
+          visit.domain_id               = request_domain&.id
+          visit.raw_query_string        = referer_uri&.query
+          visit.click_id                = tracking_params['click_id']
+          visit.http_purpose_header     = request.headers['HTTP_PURPOSE']
+          visit.http_sec_purpose_header = request.headers['HTTP_SEC_PURPOSE']
         end
 
         # Api request race conditions mean that the visit may be created on a call

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.25'
+  VERSION = '0.1.26'
 end

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict de4xM7AK3VbALLTz5dovCxohBMHdWjArlGfEnsCDQdJejSIuV1klUSg4aKo1gTz
+\restrict Ud5p9UauPQal7XJXXEjLF9AQZd3aW1bKcbk80N2WpUMYFJn9rMJxdM0XQGd3phF
 
 -- Dumped from database version 17.7 (Postgres.app)
 -- Dumped by pg_dump version 17.7 (Homebrew)
@@ -1327,7 +1327,8 @@ CREATE TABLE land.visits (
     unaltered_ingress_url text,
     click_id text,
     post_visit_at timestamp with time zone,
-    purpose_header character varying
+    http_purpose_header character varying,
+    http_sec_purpose_header character varying
 );
 
 
@@ -2420,10 +2421,17 @@ CREATE INDEX "index_land.pageviews_on_created_at" ON land.pageviews USING btree 
 
 
 --
--- Name: index_visits_on_purpose_header; Type: INDEX; Schema: land; Owner: -
+-- Name: index_visits_on_http_purpose_header; Type: INDEX; Schema: land; Owner: -
 --
 
-CREATE INDEX index_visits_on_purpose_header ON land.visits USING btree (purpose_header);
+CREATE INDEX index_visits_on_http_purpose_header ON land.visits USING btree (http_purpose_header);
+
+
+--
+-- Name: index_visits_on_http_sec_purpose_header; Type: INDEX; Schema: land; Owner: -
+--
+
+CREATE INDEX index_visits_on_http_sec_purpose_header ON land.visits USING btree (http_sec_purpose_header);
 
 
 --
@@ -3029,7 +3037,7 @@ ALTER TABLE ONLY land.visits
 -- PostgreSQL database dump complete
 --
 
-\unrestrict de4xM7AK3VbALLTz5dovCxohBMHdWjArlGfEnsCDQdJejSIuV1klUSg4aKo1gTz
+\unrestrict Ud5p9UauPQal7XJXXEjLF9AQZd3aW1bKcbk80N2WpUMYFJn9rMJxdM0XQGd3phF
 
 SET search_path TO "$user", public;
 

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -1,6 +1,12 @@
+\restrict de4xM7AK3VbALLTz5dovCxohBMHdWjArlGfEnsCDQdJejSIuV1klUSg4aKo1gTz
+
+-- Dumped from database version 17.7 (Postgres.app)
+-- Dumped by pg_dump version 17.7 (Homebrew)
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -1320,7 +1326,8 @@ CREATE TABLE land.visits (
     domain_id integer,
     unaltered_ingress_url text,
     click_id text,
-    post_visit_at timestamp with time zone
+    post_visit_at timestamp with time zone,
+    purpose_header character varying
 );
 
 
@@ -2413,6 +2420,13 @@ CREATE INDEX "index_land.pageviews_on_created_at" ON land.pageviews USING btree 
 
 
 --
+-- Name: index_visits_on_purpose_header; Type: INDEX; Schema: land; Owner: -
+--
+
+CREATE INDEX index_visits_on_purpose_header ON land.visits USING btree (purpose_header);
+
+
+--
 -- Name: keywords__u_keyword; Type: INDEX; Schema: land; Owner: -
 --
 
@@ -3015,9 +3029,12 @@ ALTER TABLE ONLY land.visits
 -- PostgreSQL database dump complete
 --
 
+\unrestrict de4xM7AK3VbALLTz5dovCxohBMHdWjArlGfEnsCDQdJejSIuV1klUSg4aKo1gTz
+
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260204204804'),
 ('20251017171657'),
 ('20250922220507'),
 ('20250922195113'),

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -91,29 +91,33 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     }
   end
 
-  context 'land visits purpose_header' do
+  context 'land visits purpose_headers' do
     let(:cookie_id) { SecureRandom.uuid }
     let(:visit_id) { SecureRandom.uuid }
 
-    it 'is set when the header HTTP_SEC_PURPOSE matches prefetch pattern' do
+    it 'is set when the header HTTP_SEC_PURPOSE is present' do
       post "/api/v1/visit?#{query_string}",
            headers: { 'HTTP_SEC_PURPOSE' => 'prefetch' },
            params: body,
            as: :json
 
-      expect(Land::Visit.first.purpose_header).to eq('prefetch')
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq(nil)
+      expect(visit.http_sec_purpose_header).to eq('prefetch')
     end
 
-    it 'is set when the header HTTP_PURPOSE matches prefetch pattern' do
+    it 'is set when the header HTTP_PURPOSE is present' do
       post "/api/v1/visit?#{query_string}",
            headers: { 'HTTP_PURPOSE' => 'prefetch' },
            params: body,
            as: :json
 
-      expect(Land::Visit.first.purpose_header).to eq('prefetch')
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq('prefetch')
+      expect(visit.http_sec_purpose_header).to eq(nil)
     end
 
-    it 'sets the purpose_header value if neither is prefetch' do
+    it 'sets both headers values if present' do
       post "/api/v1/visit?#{query_string}",
            headers: {
              'HTTP_PURPOSE' => 'other-purpose',
@@ -122,51 +126,19 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
            params: body,
            as: :json
 
-      expect(Land::Visit.first.purpose_header).to eq('other-purpose')
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq('other-purpose')
+      expect(visit.http_sec_purpose_header).to eq('other-purpose')
     end
 
-    it 'sets the purpose_header value if neither is prefetch' do
-      post "/api/v1/visit?#{query_string}",
-           headers: {
-             'HTTP_PURPOSE' => 'other-purpose',
-             'HTTP_SEC_PURPOSE' => 'other-purpose'
-           },
-           params: body,
-           as: :json
-
-      expect(Land::Visit.first.purpose_header).to eq('other-purpose')
-    end
-
-    it 'sets the purpose_header to prefetch if HTTP_PURPOSE is prefetch' do
-      post "/api/v1/visit?#{query_string}",
-           headers: {
-             'HTTP_PURPOSE' => 'prefetch',
-             'HTTP_SEC_PURPOSE' => 'other-purpose'
-           },
-           params: body,
-           as: :json
-
-      expect(Land::Visit.first.purpose_header).to eq('prefetch')
-    end
-
-    it 'sets the purpose_header to prefetch if HTTP_SEC_PURPOSE is prefetch' do
-      post "/api/v1/visit?#{query_string}",
-           headers: {
-             'HTTP_PURPOSE' => 'other-purpose',
-             'HTTP_SEC_PURPOSE' => 'prefetch'
-           },
-           params: body,
-           as: :json
-
-      expect(Land::Visit.first.purpose_header).to eq('prefetch')
-    end
-
-    it 'sets the purpose_header to nil if headers not present' do
+    it 'sets both headers to nil if not present' do
       post "/api/v1/visit?#{query_string}",
            params: body,
            as: :json
 
-      expect(Land::Visit.first.purpose_header).to eq(nil)
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq(nil)
+      expect(visit.http_sec_purpose_header).to eq(nil)
     end
   end
 

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -117,6 +117,28 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.http_sec_purpose_header).to eq(nil)
     end
 
+    it 'is set when the header http_sec_purpose is present' do
+      post "/api/v1/visit?#{query_string}",
+           headers: { 'http_sec_purpose' => 'prefetch' },
+           params: body,
+           as: :json
+
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq(nil)
+      expect(visit.http_sec_purpose_header).to eq('prefetch')
+    end
+
+    it 'is set when the header http_purpose is present' do
+      post "/api/v1/visit?#{query_string}",
+           headers: { 'http_purpose' => 'prefetch' },
+           params: body,
+           as: :json
+
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq('prefetch')
+      expect(visit.http_sec_purpose_header).to eq(nil)
+    end
+
     it 'sets both headers values if present' do
       post "/api/v1/visit?#{query_string}",
            headers: {

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -91,6 +91,85 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     }
   end
 
+  context 'land visits purpose_header' do
+    let(:cookie_id) { SecureRandom.uuid }
+    let(:visit_id) { SecureRandom.uuid }
+
+    it 'is set when the header HTTP_SEC_PURPOSE matches prefetch pattern' do
+      post "/api/v1/visit?#{query_string}",
+           headers: { 'HTTP_SEC_PURPOSE' => 'prefetch' },
+           params: body,
+           as: :json
+
+      expect(Land::Visit.first.purpose_header).to eq('prefetch')
+    end
+
+    it 'is set when the header HTTP_PURPOSE matches prefetch pattern' do
+      post "/api/v1/visit?#{query_string}",
+           headers: { 'HTTP_PURPOSE' => 'prefetch' },
+           params: body,
+           as: :json
+
+      expect(Land::Visit.first.purpose_header).to eq('prefetch')
+    end
+
+    it 'sets the purpose_header value if neither is prefetch' do
+      post "/api/v1/visit?#{query_string}",
+           headers: {
+             'HTTP_PURPOSE' => 'other-purpose',
+             'HTTP_SEC_PURPOSE' => 'other-purpose'
+           },
+           params: body,
+           as: :json
+
+      expect(Land::Visit.first.purpose_header).to eq('other-purpose')
+    end
+
+    it 'sets the purpose_header value if neither is prefetch' do
+      post "/api/v1/visit?#{query_string}",
+           headers: {
+             'HTTP_PURPOSE' => 'other-purpose',
+             'HTTP_SEC_PURPOSE' => 'other-purpose'
+           },
+           params: body,
+           as: :json
+
+      expect(Land::Visit.first.purpose_header).to eq('other-purpose')
+    end
+
+    it 'sets the purpose_header to prefetch if HTTP_PURPOSE is prefetch' do
+      post "/api/v1/visit?#{query_string}",
+           headers: {
+             'HTTP_PURPOSE' => 'prefetch',
+             'HTTP_SEC_PURPOSE' => 'other-purpose'
+           },
+           params: body,
+           as: :json
+
+      expect(Land::Visit.first.purpose_header).to eq('prefetch')
+    end
+
+    it 'sets the purpose_header to prefetch if HTTP_SEC_PURPOSE is prefetch' do
+      post "/api/v1/visit?#{query_string}",
+           headers: {
+             'HTTP_PURPOSE' => 'other-purpose',
+             'HTTP_SEC_PURPOSE' => 'prefetch'
+           },
+           params: body,
+           as: :json
+
+      expect(Land::Visit.first.purpose_header).to eq('prefetch')
+    end
+
+    it 'sets the purpose_header to nil if headers not present' do
+      post "/api/v1/visit?#{query_string}",
+           params: body,
+           as: :json
+
+      expect(Land::Visit.first.purpose_header).to eq(nil)
+    end
+  end
+
   context 'when the request is successful and /api/v1/visit is the first request' do
     let(:cookie_id) { SecureRandom.uuid }
     let(:visit_id) { SecureRandom.uuid }


### PR DESCRIPTION
Sets `land.visits.http_purpose_header` and `land.visits.http_sec_purpose_header` if they are passed in the first request header per cookie_id/visit_id


Companion PR: https://github.com/cpcmarketing/billdoctor-web/pull/1988