### PR TITLE
Feat/x purpose header persistence

### DIFF
--- a/lib/land/trackers/api_tracker.rb
+++ b/lib/land/trackers/api_tracker.rb
@@ -55,7 +55,7 @@ module Land
           visit.domain_id               = request_domain&.id
           visit.raw_query_string        = referer_uri&.query
           visit.click_id                = tracking_params['click_id']
-          visit.http_purpose_header     = request.headers['HTTP_PURPOSE']     || request.headers['http_purpose']
+          visit.http_purpose_header     = purpose_header
           visit.http_sec_purpose_header = request.headers['HTTP_SEC_PURPOSE'] || request.headers['http_sec_purpose']
         end
 
@@ -87,6 +87,13 @@ module Land
         retry if e.message == 'Validation failed: Visit has already been taken'
 
         raise e
+      end
+
+      # the purpose header is used to indicate in prefetch traffic
+      def purpose_header
+        request.headers['HTTP_PURPOSE']     || request.headers['http_purpose']   || # google header
+          request.headers['HTTP_X_PURPOSE'] || request.headers['http_x_purpose'] || # meta browser header
+          request.headers['HTTP_X_MOZ']     || request.headers['http_x_moz']        # mozilla browser header
       end
 
       def set_post_visit_at

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.26'
+  VERSION = '0.1.27'
 end

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -106,6 +106,28 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
       expect(visit.http_sec_purpose_header).to eq('prefetch')
     end
 
+    it 'is set when the header X-Purpose (meta browser) is present' do
+      post "/api/v1/visit?#{query_string}",
+           headers: { 'X-Purpose' => 'preview' },
+           params: body,
+           as: :json
+
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq('preview')
+      expect(visit.http_sec_purpose_header).to eq(nil)
+    end
+
+    it 'is set when the header X-Moz (meta browser) is present' do
+      post "/api/v1/visit?#{query_string}",
+           headers: { 'X-Moz' => 'preview' },
+           params: body,
+           as: :json
+
+      visit = Land::Visit.first
+      expect(visit.http_purpose_header).to eq('preview')
+      expect(visit.http_sec_purpose_header).to eq(nil)
+    end
+
     it 'is set when the header HTTP_PURPOSE is present' do
       post "/api/v1/visit?#{query_string}",
            headers: { 'HTTP_PURPOSE' => 'prefetch' },


### PR DESCRIPTION
- adds `X-Purpose` `X-Moz` header logic for setting `land.visits.http_purpose_header`