### PR TITLE
feat(app): Remove all autogeneration of cookie_id and visit_id

### DIFF
--- a/app/models/land/cookie.rb
+++ b/app/models/land/cookie.rb
@@ -8,9 +8,5 @@ module Land
     has_many :visits
 
     validates :cookie_id, presence: true, uniqueness: true
-
-    after_initialize do
-      self.id ||= SecureRandom.uuid
-    end
   end
 end

--- a/app/models/land/visit.rb
+++ b/app/models/land/visit.rb
@@ -13,9 +13,5 @@ module Land
     has_many :pageviews, dependent: :destroy
 
     validates :visit_id, presence: true, uniqueness: true
-
-    after_initialize do
-      self.id ||= SecureRandom.uuid
-    end
   end
 end

--- a/db/migrate/20260211170328_remove_default_generation_visit_id_cookie_id.rb
+++ b/db/migrate/20260211170328_remove_default_generation_visit_id_cookie_id.rb
@@ -1,0 +1,6 @@
+class RemoveDefaultGenerationVisitIdCookieId < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default 'land.visits',  :visit_id,  nil
+    change_column_default 'land.cookies', :cookie_id, nil
+  end
+end

--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.27'
+  VERSION = '0.1.28'
 end

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -1,5 +1,3 @@
-\restrict hCZStYqohe8uw6LDSx8BiBZlSGg0lM34PUxXJDYMCdgE2w8UjvOYSdgvmWiZX3m
-
 -- Dumped from database version 17.7 (Postgres.app)
 -- Dumped by pg_dump version 17.7 (Homebrew)
 
@@ -3037,8 +3035,6 @@ ALTER TABLE ONLY land.visits
 -- PostgreSQL database dump complete
 --
 
-\unrestrict hCZStYqohe8uw6LDSx8BiBZlSGg0lM34PUxXJDYMCdgE2w8UjvOYSdgvmWiZX3m
-
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
@@ -3059,4 +3055,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20201024041516'),
 ('20200724201945'),
 ('20200103012916');
-

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict Ud5p9UauPQal7XJXXEjLF9AQZd3aW1bKcbk80N2WpUMYFJn9rMJxdM0XQGd3phF
+\restrict hCZStYqohe8uw6LDSx8BiBZlSGg0lM34PUxXJDYMCdgE2w8UjvOYSdgvmWiZX3m
 
 -- Dumped from database version 17.7 (Postgres.app)
 -- Dumped by pg_dump version 17.7 (Homebrew)
@@ -433,7 +433,7 @@ ALTER SEQUENCE land.contents_content_id_seq OWNED BY land.contents.content_id;
 --
 
 CREATE TABLE land.cookies (
-    cookie_id uuid DEFAULT public.uuid_generate_v4() NOT NULL
+    cookie_id uuid NOT NULL
 );
 
 
@@ -1313,7 +1313,7 @@ ALTER SEQUENCE land.user_agents_user_agent_id_seq OWNED BY land.user_agents.user
 --
 
 CREATE TABLE land.visits (
-    visit_id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    visit_id uuid NOT NULL,
     cookie_id uuid NOT NULL,
     user_agent_id integer NOT NULL,
     attribution_id integer NOT NULL,
@@ -3037,11 +3037,12 @@ ALTER TABLE ONLY land.visits
 -- PostgreSQL database dump complete
 --
 
-\unrestrict Ud5p9UauPQal7XJXXEjLF9AQZd3aW1bKcbk80N2WpUMYFJn9rMJxdM0XQGd3phF
+\unrestrict hCZStYqohe8uw6LDSx8BiBZlSGg0lM34PUxXJDYMCdgE2w8UjvOYSdgvmWiZX3m
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260211170328'),
 ('20260204204804'),
 ('20251017171657'),
 ('20250922220507'),

--- a/spec/land/trackers/api_tracker_spec.rb
+++ b/spec/land/trackers/api_tracker_spec.rb
@@ -601,6 +601,34 @@ RSpec.describe 'Land::Trackers::ApiTracker', type: :request do
     end
   end
 
+  context 'when invalid UUIDs are sent in' do
+    context 'for cookie_id' do
+      let(:cookie_id) { '' }
+      let(:visit_id) { SecureRandom.uuid }
+
+      it 'should not create a visit or cookie' do
+        post "/api/v1/visit?#{query_string}", params: body,
+                                              as: :json
+
+        expect(Land::Visit.count).to eq(0)
+        expect(Land::Cookie.count).to eq(0)
+      end
+    end
+
+    context 'for visit_id' do
+      let(:cookie_id) { SecureRandom.uuid }
+      let(:visit_id) { '' }
+
+      it 'should not create a visit' do
+        post "/api/v1/visit?#{query_string}", params: body,
+                                              as: :json
+
+        expect(Land::Visit.count).to eq(0)
+        expect(Land::Cookie.count).to eq(1)
+      end
+    end
+  end
+
   context 'two visits with different device resolutions' do
     context 'and it update the device resolution when the device resolutions are different' do
       let(:cookie_id) { SecureRandom.uuid }


### PR DESCRIPTION
Removes all auto-generation of cookie_id and visit_id

Compainion PR https://github.com/cpcmarketing/billdoctor-web/pull/1991